### PR TITLE
fix: improve icon spacing & add new-tab links (v1.2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,47 +37,47 @@
 
 <!-- Row 1 (9 icons) -->
 <p>
-  <a href="https://www.linux.org/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=linux"/></a>
-  <a href="https://www.gnu.org/software/bash/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=bash"/></a>
-  <a href="https://git-scm.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=git"/></a>
-  <a href="https://github.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=github"/></a>
-  <a href="https://www.jenkins.io/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=jenkins"/></a>
-  <a href="https://github.com/features/actions"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=githubactions"/></a>
-  <a href="https://www.ansible.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=ansible"/></a>
-  <a href="https://www.docker.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=docker"/></a>
-  <a href="https://kubernetes.io/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=kubernetes"/></a>
+  <a target="_blank" href="https://www.linux.org/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=linux"/></a>
+  <a target="_blank" href="https://www.gnu.org/software/bash/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=bash"/></a>
+  <a target="_blank" href="https://git-scm.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=git"/></a>
+  <a target="_blank" href="https://github.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=github"/></a>
+  <a target="_blank" href="https://www.jenkins.io/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=jenkins"/></a>
+  <a target="_blank" href="https://github.com/features/actions"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=githubactions"/></a>
+  <a target="_blank" href="https://www.ansible.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=ansible"/></a>
+  <a target="_blank" href="https://www.docker.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=docker"/></a>
+  <a target="_blank" href="https://kubernetes.io/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=kubernetes"/></a>
 </p>
 
 <!-- Row 2 (7 icons) -->
 <p>
-  <a href="https://aws.amazon.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=aws"/></a>
-  <a href="https://www.terraform.io/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=terraform"/></a>
-  <a href="https://www.python.org/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=python"/></a>
-  <a href="https://flask.palletsprojects.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=flask"/></a>
-  <a href="https://prometheus.io/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=prometheus"/></a>
-  <a href="https://grafana.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=grafana"/></a>
-  <a href="https://httpd.apache.org/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=apache"/></a>
+  <a target="_blank" href="https://aws.amazon.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=aws"/></a>
+  <a target="_blank" href="https://www.terraform.io/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=terraform"/></a>
+  <a target="_blank" href="https://www.python.org/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=python"/></a>
+  <a target="_blank" href="https://flask.palletsprojects.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=flask"/></a>
+  <a target="_blank" href="https://prometheus.io/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=prometheus"/></a>
+  <a target="_blank" href="https://grafana.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=grafana"/></a>
+  <a target="_blank" href="https://httpd.apache.org/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=apache"/></a>
 </p>
 
 <!-- Row 3 (5 icons) -->
 <p>
-  <a href="https://nginx.org/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=nginx"/>
-  <a href="https://www.mysql.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=mysql"/>
-  <a href="https://www.postgresql.org/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=postgresql"/>
-  <a href="https://www.notion.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=notion"/>
-  <a href="https://code.visualstudio.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=vscode"/>
+  <a target="_blank" href="https://nginx.org/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=nginx"/>
+  <a target="_blank" href="https://www.mysql.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=mysql"/>
+  <a target="_blank" href="https://www.postgresql.org/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=postgresql"/>
+  <a target="_blank" href="https://www.notion.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=notion"/>
+  <a target="_blank" href="https://code.visualstudio.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=vscode"/>
 </p>
 
 <!-- Row 4 (3 icons) -->
 <p>  
-  <a href="https://developer.mozilla.org/en-US/docs/Web/HTML"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=html"/>
-  <a href="https://developer.mozilla.org/en-US/docs/Web/CSS"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=css"/>
-  <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=js"/>
+  <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=html"/>
+  <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=css"/>
+  <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=js"/>
 </p>
 
 <!-- Row 5 (1 icon) -->
 <p>
-  <a href="https://vercel.com/"><img style="margin: 0 10px;" src="https://go-skill-icons.vercel.app/api/icons?i=vercel"/>
+  <a target="_blank" href="https://vercel.com/"><img hspace="10" src="https://go-skill-icons.vercel.app/api/icons?i=vercel"/>
 </p>
 
 </div>


### PR DESCRIPTION
Closes #9 

### 🧩 Changes

- Fixed inconsistent spacing between tech stack icons
- Added `target="_blank"` for icon links to open in a new tab
- Ensured proper alignment and symmetry across all icon rows

### ✅ Version
`v1.2.1`