### PR TITLE
feat: add GitHub stats and most used languages section (v1.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,16 @@
 <a href="https://github.com/hafeezzshs/k8s-eks-2048-app"><img align="center" width="355" hspace="10" src="https://github-readme-stats.vercel.app/api/pin/?username=hafeezzshs&repo=k8s-eks-2048-app&theme=react&bg_color=1F222E&title_color=F85D7F&hide_border=false&icon_color=F8D866&show_icons=true" alt="k8s-eks-2048-app"></a>
 
 </div>
+
+---
+
+<h2 align="center">📊 GitHub Profile Stats</h2>
+
+<div align="center">
+
+<a href="https://github.com/hafeezzshs"><img align="center" height="192"  hspace="10" src="https://github-readme-stats.vercel.app/api?username=hafeezzshs&theme=react&bg_color=1F222E&title_color=F85D7F&hide_border=false&icon_color=F8D866&show_icons=true&hide=contribs&show=reviews,prs_merged,prs_merged_percentage&rank_icon=github&include_all_commits=true&custom_title=My%20GitHub%20Profile%20Stats" alt="github-stats"></a>
+<a href="https://github.com/hafeezzshs"><img align="center" height="192" hspace="10" src="https://github-readme-stats.vercel.app/api/top-langs?username=hafeezzshs&theme=react&bg_color=1F222E&title_color=F85D7F&hide_border=false&layout=compact&langs_count=10" alt="most-used-languages"></a>
+
+<i>**Note:** Most used languages represent the breakdown of my public repositories and do not necessarily indicate my skill level or experience.</i>
+
+</div>


### PR DESCRIPTION
Closes #15

### 🧩 Changes
- Added GitHub Stats card displaying contributions and commit activity, using `github-readme-stats` API
- Added Most used languages card with percentage-based layout
- Responsive side-by-side alignment for clean visual structure
- Customized theme and title for a clean, personal touch
- Positioned below Featured Repositories section for visual continuity
- Ensured responsive layout and consistent alignment

### ✅ Version
`v1.4.0`